### PR TITLE
Add Android build skeleton and workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,40 @@
+name: Build Android APK
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v2
+        with:
+          api-level: 33
+          build-tools: 33.0.2
+          ndk: 25.2.9519653
+          accept-licenses: true
+
+      - name: Build debug APK
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: '8.2'
+          build-root-directory: android
+          arguments: assembleDebug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: OrcaSlicer-debug-apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ src/OrcaSlicer-doc/
 **/.flatpak-builder/
 resources/profiles/user/default
 *.code-workspace
+# Android build artifacts
+android/.gradle/
+android/local.properties
+android/app/build/
+android/build/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.orca.orcaslicer'
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.orca.orcaslicer"
+        minSdk 24
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.orca.orcaslicer">
+
+    <application
+        android:label="@string/app_name"
+        android:allowBackup="true"
+        android:supportsRtl="true">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/orca/orcaslicer/MainActivity.java
+++ b/android/app/src/main/java/com/orca/orcaslicer/MainActivity.java
@@ -1,0 +1,15 @@
+package com.orca.orcaslicer;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.TextView;
+
+public class MainActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        TextView tv = new TextView(this);
+        tv.setText("Hello from OrcaSlicer");
+        setContentView(tv);
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">OrcaSlicer</string>
+</resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.1'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "OrcaSlicerAndroid"
+include(":app")


### PR DESCRIPTION
## Summary
- add minimal Android app project scaffold
- configure CI workflow to assemble Android debug APK and upload artifact
- ignore Android build outputs

## Testing
- `gradle assembleDebug` *(fails: 403 Forbidden)*
- `cmake -S . -B build` *(fails: Could NOT find DBus)*

------
https://chatgpt.com/codex/tasks/task_e_68903b1eda58832d91536cd775007a66